### PR TITLE
support auth_chain_b(bugs with tls1.2_ticket_auth)

### DIFF
--- a/protocol/auth_chain_a.go
+++ b/protocol/auth_chain_a.go
@@ -8,13 +8,14 @@ import (
 	"crypto/cipher"
 	"encoding/base64"
 	"encoding/binary"
-	"github.com/mzz2017/shadowsocksR/ssr"
-	cipher2 "github.com/mzz2017/shadowsocksR/streamCipher"
-	"github.com/mzz2017/shadowsocksR/tools"
 	"math/rand"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/mzz2017/shadowsocksR/ssr"
+	cipher2 "github.com/mzz2017/shadowsocksR/streamCipher"
+	"github.com/mzz2017/shadowsocksR/tools"
 )
 
 func init() {
@@ -58,6 +59,9 @@ func NewAuthChainA() IProtocol {
 
 func (a *authChainA) SetServerInfo(s *ssr.ServerInfoForObfs) {
 	a.ServerInfoForObfs = *s
+	if a.salt == "auth_chain_b" {
+		a.initDataSize()
+	}
 }
 
 func (a *authChainA) GetServerInfo() (s *ssr.ServerInfoForObfs) {

--- a/protocol/auth_chain_b.go
+++ b/protocol/auth_chain_b.go
@@ -1,0 +1,86 @@
+package protocol
+
+import (
+	"bytes"
+	"sort"
+
+	"github.com/mzz2017/shadowsocksR/tools"
+)
+
+func init() {
+	register("auth_chain_b", NewAuthChainB)
+}
+
+func NewAuthChainB() IProtocol {
+	a := &authChainA{
+		salt:       "auth_chain_b",
+		hmac:       tools.HmacMD5,
+		hashDigest: tools.SHA1Sum,
+		rnd:        authChainBGetRandLen,
+		recvInfo: recvInfo{
+			recvID: 1,
+			buffer: new(bytes.Buffer),
+		},
+	}
+	return a
+}
+
+func (a *authChainA) initDataSize() {
+	if len(a.Key) == 0 {
+		return
+	}
+	// python version
+	random := &tools.Shift128plusContext{}
+	// libev version
+	// random := a.randomServer
+	random.InitFromBin(a.Key)
+	len := random.Next()%8 + 4
+	for i := 0; i < int(len); i++ {
+		a.dataSizeList = append(a.dataSizeList, (int)(random.Next()%2340%2040%1440))
+	}
+	sort.Ints(a.dataSizeList)
+
+	len = random.Next()%16 + 8
+	for i := 0; i < int(len); i++ {
+		a.dataSizeList2 = append(a.dataSizeList2, (int)(random.Next()%2340%2040%1440))
+	}
+	sort.Ints(a.dataSizeList2)
+}
+
+func authChainBGetRandLen(dataLength int, random *tools.Shift128plusContext, lastHash []byte, dataSizeList, dataSizeList2 []int, overhead int) int {
+	if dataLength > 1440 {
+		return 0
+	}
+	random.InitFromBinDatalen(lastHash[:16], dataLength)
+	// python vserion, lower_bound
+	pos := sort.SearchInts(dataSizeList, dataLength+overhead)
+	// libev version, upper_bound
+	// pos := sort.Search(len(dataSizeList), func(i int) bool { return dataSizeList[i] > dataLength+overhead })
+	finalPos := uint64(pos) + random.Next()%uint64(len(dataSizeList))
+	if finalPos < uint64(len(dataSizeList)) {
+		return dataSizeList[finalPos] - dataLength - overhead
+	}
+
+	// python vserion, lower_bound
+	pos = sort.SearchInts(dataSizeList2, dataLength+overhead)
+	// libev version, upper_bound
+	// pos = sort.Search(len(dataSizeList2), func(i int) bool { return dataSizeList2[i] > dataLength+overhead })
+	finalPos = uint64(pos) + random.Next()%uint64(len(dataSizeList2))
+	if finalPos < uint64(len(dataSizeList2)) {
+		return dataSizeList2[finalPos] - dataLength - overhead
+	}
+	if finalPos < uint64(pos+len(dataSizeList2)-1) {
+		return 0
+	}
+
+	if dataLength > 1300 {
+		return int(random.Next() % 31)
+	}
+	if dataLength > 900 {
+		return int(random.Next() % 127)
+	}
+	if dataLength > 400 {
+		return int(random.Next() % 521)
+	}
+	return int(random.Next() % 1021)
+}

--- a/tools/obfsutil.go
+++ b/tools/obfsutil.go
@@ -21,6 +21,14 @@ type Shift128plusContext struct {
 	v [2]uint64
 }
 
+func (ctx *Shift128plusContext) InitFromBin(bin []byte) {
+	var fillBin [16]byte
+	copy(fillBin[:], bin)
+
+	ctx.v[0] = binary.LittleEndian.Uint64(fillBin[:8])
+	ctx.v[1] = binary.LittleEndian.Uint64(fillBin[8:])
+}
+
 func (ctx *Shift128plusContext) InitFromBinDatalen(bin []byte, datalen int) {
 	var fillBin [16]byte
 	copy(fillBin[:], bin)


### PR DESCRIPTION
与tls1.2_ticket_auth一起使用时服务端会报错checksum error，与其他混淆工作正常。

服务端使用的python版本。[Docker: 4kerccc/shadowsocksr](https://hub.docker.com/r/4kerccc/shadowsocksr)

翻了python和libev源码，实现略有差别，具体在于二分搜索和初始化`dataSizeList`时使用的`Shift128plusContext`不同。这个pr中无论使用哪一种都会出错。

python ssr client可以正常连接python ssr server，libev ssr client连接python ssr server时也会checksum error，使用ssr-libev的[ssrb](https://github.com/shadowsocksRb/shadowsocksRb-android)却又能正常连接python ssr server(迷惑

作者有时间的话可以看一下（实在找不出错误在哪了